### PR TITLE
Keinen Home-Link ausgeben, wenn leer

### DIFF
--- a/classes/class.rex_breadcrumb_nav.inc.php
+++ b/classes/class.rex_breadcrumb_nav.inc.php
@@ -107,7 +107,7 @@ class rex_breadcrumb_nav {
 
 					if (intval($id) === $REX['ARTICLE_ID']) {
 						$html .= $linkText;
-					} else {
+					} else if ( $linkText != '') {
 						$html .= '<a href="' . $article->getUrl() . '">' . $linkText . '</a>';
 					}
 


### PR DESCRIPTION
Wenn $nav->setHideStartArticleName(true); und $nav->setStartArticleIconClass('');, dann ist $linkText leer und der Webdesigner möchte dann auch keinen leeren Anker-Tag zur Startseite haben.